### PR TITLE
Added button to clear last error on agent dashboard

### DIFF
--- a/agent/Components/Pages/Dashboard.razor
+++ b/agent/Components/Pages/Dashboard.razor
@@ -58,6 +58,13 @@
                 <CardHeaderContent>
                     <MudText Typo="Typo.h6">Last error</MudText>
                 </CardHeaderContent>
+                <CardHeaderActions>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Default" Size="Size.Small"
+                               Disabled="@(!Health.LastErrorUtc.HasValue)"
+                               OnClick="ClearLastErrorAsync">
+                        Clear error
+                    </MudButton>
+                </CardHeaderActions>
             </MudCardHeader>
             <MudCardContent>
                 <MudText Typo="Typo.body2">@(Health.LastErrorUtc?.ToString("u") ?? "—")</MudText>
@@ -240,6 +247,13 @@
     {
         Health.ClearFileActivityHistory();
         Snackbar.Add("File activity history cleared.", Severity.Success);
+        return Task.CompletedTask;
+    }
+
+    private Task ClearLastErrorAsync()
+    {
+        Health.ClearLastError();
+        Snackbar.Add("Last error cleared.", Severity.Success);
         return Task.CompletedTask;
     }
 

--- a/agent/HarvesterHealthState.cs
+++ b/agent/HarvesterHealthState.cs
@@ -260,6 +260,20 @@ public sealed class HarvesterHealthState
         RaiseChanged();
     }
 
+    /// <summary>
+    ///     Clears the displayed last error timestamp and message. Does not reset upload counters or file activity history.
+    /// </summary>
+    public void ClearLastError()
+    {
+        lock (_lock)
+        {
+            LastErrorUtc = null;
+            LastErrorMessage = null;
+        }
+
+        RaiseChanged();
+    }
+
     private void AddHistoryEntry(HarvestedFileHistoryEntry entry)
     {
         List<HarvestedFileHistoryEntry> list = [.. FileActivityHistory];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Clear error" button to the Last Error card in the dashboard, allowing users to easily clear the most recently recorded system error. The button is automatically disabled when no error exists and displays a helpful confirmation message when the error has been successfully cleared and removed from view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->