### PR TITLE
Added more events to FS change watcher

### DIFF
--- a/WinDbgSymbolsCachingProxy.sln
+++ b/WinDbgSymbolsCachingProxy.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33516.290
@@ -43,6 +43,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Installer", "Installer", "{1860D2E4-5C43-71D5-59A5-599A4DE1DF67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinDbgSymbolsCachingProxy.Installer", "installer\WinDbgSymbolsCachingProxy.Installer.csproj", "{BA98B9AC-930F-41F9-9622-0664A86B5E4F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HarvestingAgent.Tests", "tests\HarvestingAgent.Tests\HarvestingAgent.Tests.csproj", "{AD2461FA-8787-4E15-BE2E-132D5F3AB820}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -135,6 +137,18 @@ Global
 		{BA98B9AC-930F-41F9-9622-0664A86B5E4F}.Release|x64.Build.0 = Release|Any CPU
 		{BA98B9AC-930F-41F9-9622-0664A86B5E4F}.Release|x86.ActiveCfg = Release|Any CPU
 		{BA98B9AC-930F-41F9-9622-0664A86B5E4F}.Release|x86.Build.0 = Release|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Debug|x64.Build.0 = Debug|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Debug|x86.Build.0 = Debug|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Release|x64.ActiveCfg = Release|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Release|x64.Build.0 = Release|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Release|x86.ActiveCfg = Release|Any CPU
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -146,5 +160,6 @@ Global
 		{95B2C961-372A-4F72-8319-051991F869D5} = {88AF9BE8-9E86-4A3F-AD7C-BFE704D9AB7A}
 		{F576E9F2-AD9C-4CA0-A83F-0A68B31E6680} = {31214E1B-4CF4-44C7-9DCB-901A06D4AE3D}
 		{BA98B9AC-930F-41F9-9622-0664A86B5E4F} = {1860D2E4-5C43-71D5-59A5-599A4DE1DF67}
+		{AD2461FA-8787-4E15-BE2E-132D5F3AB820} = {31214E1B-4CF4-44C7-9DCB-901A06D4AE3D}
 	EndGlobalSection
 EndGlobal

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -20,6 +20,8 @@ public sealed class HarvesterRuntime : IDisposable
         public required string Path { get; init; }
         public required string FileName { get; init; }
         public required WatcherBinding Binding { get; set; }
+        public required long WatcherSetGeneration { get; init; }
+        public required CancellationToken WatcherSetCancellationToken { get; init; }
         public int Revision { get; set; }
     }
 
@@ -91,6 +93,8 @@ public sealed class HarvesterRuntime : IDisposable
     private readonly object _gate = new();
     private Dictionary<FileSystemWatcher, WatcherBinding>? _maps;
     private readonly Dictionary<string, PendingFileEvent> _pendingFileEvents = new(StringComparer.OrdinalIgnoreCase);
+    private CancellationTokenSource _watcherSetCancellation = new();
+    private long _watcherSetGeneration;
     private bool _disposed;
 
     public HarvesterRuntime(
@@ -455,6 +459,7 @@ public sealed class HarvesterRuntime : IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
+            InvalidatePendingFileEventsLocked();
 
             AgentSettingsDocument doc = _store.GetSnapshot();
             ServiceConfig serviceConfig = doc.ToServiceConfig();
@@ -606,6 +611,7 @@ public sealed class HarvesterRuntime : IDisposable
             ThrowIfDisposed();
             cancellationToken.ThrowIfCancellationRequested();
             _store.UpdateHarvestingEnabled(enabled);
+            InvalidatePendingFileEventsLocked();
 
             if (_maps is null)
             {
@@ -647,6 +653,7 @@ public sealed class HarvesterRuntime : IDisposable
             }
 
             _disposed = true;
+            InvalidatePendingFileEventsLocked();
             DisposeWatchersLocked();
             _maps = null;
         }
@@ -655,6 +662,14 @@ public sealed class HarvesterRuntime : IDisposable
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private void InvalidatePendingFileEventsLocked()
+    {
+        _watcherSetGeneration++;
+        _watcherSetCancellation.Cancel();
+        _watcherSetCancellation = new CancellationTokenSource();
+        _pendingFileEvents.Clear();
     }
 
     private void DisposeWatchersLocked()
@@ -724,6 +739,11 @@ public sealed class HarvesterRuntime : IDisposable
                 return;
             }
 
+            if (!watcher.EnableRaisingEvents)
+            {
+                return;
+            }
+
             if (binding.Servers.Count == 0)
             {
                 return;
@@ -753,6 +773,8 @@ public sealed class HarvesterRuntime : IDisposable
                 Path = path,
                 FileName = fileName,
                 Binding = binding,
+                WatcherSetGeneration = _watcherSetGeneration,
+                WatcherSetCancellationToken = _watcherSetCancellation.Token,
                 Revision = 1
             };
             _pendingFileEvents.Add(path, pendingToProcess);
@@ -771,6 +793,10 @@ public sealed class HarvesterRuntime : IDisposable
 
     private async Task ProcessPendingFileEventAsync(PendingFileEvent pending, CancellationToken stopping)
     {
+        using CancellationTokenSource linkedCancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(stopping, pending.WatcherSetCancellationToken);
+        CancellationToken cancellationToken = linkedCancellation.Token;
+
         try
         {
             while (true)
@@ -781,7 +807,8 @@ public sealed class HarvesterRuntime : IDisposable
                 lock (_gate)
                 {
                     if (!_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) ||
-                        !ReferenceEquals(current, pending))
+                        !ReferenceEquals(current, pending) ||
+                        pending.WatcherSetGeneration != _watcherSetGeneration)
                     {
                         return;
                     }
@@ -790,12 +817,13 @@ public sealed class HarvesterRuntime : IDisposable
                     binding = pending.Binding;
                 }
 
-                await Task.Delay(FileEventDebounceInterval, stopping);
+                await Task.Delay(FileEventDebounceInterval, cancellationToken);
 
                 lock (_gate)
                 {
                     if (!_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) ||
-                        !ReferenceEquals(current, pending))
+                        !ReferenceEquals(current, pending) ||
+                        pending.WatcherSetGeneration != _watcherSetGeneration)
                     {
                         return;
                     }
@@ -808,11 +836,15 @@ public sealed class HarvesterRuntime : IDisposable
 
                 try
                 {
-                    await ProcessDetectedFileAsync(binding, pending.Path, pending.FileName, stopping);
+                    await ProcessDetectedFileAsync(binding, pending.Path, pending.FileName, cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
                     throw;
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+                {
+                    _logger.LogDebug(ex, "Skipping symbol upload because {Path} no longer exists", pending.Path);
                 }
                 catch (Exception ex)
                 {
@@ -824,7 +856,8 @@ public sealed class HarvesterRuntime : IDisposable
                 lock (_gate)
                 {
                     if (!_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) ||
-                        !ReferenceEquals(current, pending))
+                        !ReferenceEquals(current, pending) ||
+                        pending.WatcherSetGeneration != _watcherSetGeneration)
                     {
                         return;
                     }

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -665,7 +665,9 @@ public sealed class HarvesterRuntime : IDisposable
     private void InvalidatePendingFileEventsLocked()
     {
         _watcherSetGeneration++;
-        _watcherSetCancellation.Cancel();
+        CancellationTokenSource oldCancellation = _watcherSetCancellation;
+        oldCancellation.Cancel();
+        oldCancellation.Dispose();
         _watcherSetCancellation = new CancellationTokenSource();
         _pendingFileEvents.Clear();
     }

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -19,7 +19,7 @@ public sealed class HarvesterRuntime : IDisposable
     {
         public required string Path { get; init; }
         public required string FileName { get; init; }
-        public required WatcherBinding Binding { get; set; }
+        public required List<WatcherBinding> Bindings { get; init; }
         public required long WatcherSetGeneration { get; init; }
         public required CancellationToken WatcherSetCancellationToken { get; init; }
         public int Revision { get; set; }
@@ -758,7 +758,11 @@ public sealed class HarvesterRuntime : IDisposable
 
             if (_pendingFileEvents.TryGetValue(path, out PendingFileEvent? pending))
             {
-                pending.Binding = binding;
+                if (!pending.Bindings.Contains(binding))
+                {
+                    pending.Bindings.Add(binding);
+                }
+
                 pending.Revision++;
                 _logger.LogTrace(
                     "Coalesced {ChangeType} event for {Path} into pending revision {Revision}",
@@ -772,7 +776,7 @@ public sealed class HarvesterRuntime : IDisposable
             {
                 Path = path,
                 FileName = fileName,
-                Binding = binding,
+                Bindings = [binding],
                 WatcherSetGeneration = _watcherSetGeneration,
                 WatcherSetCancellationToken = _watcherSetCancellation.Token,
                 Revision = 1
@@ -814,7 +818,7 @@ public sealed class HarvesterRuntime : IDisposable
                     }
 
                     revision = pending.Revision;
-                    binding = pending.Binding;
+                    binding = MergeBindings(pending.Bindings);
                 }
 
                 await Task.Delay(FileEventDebounceInterval, cancellationToken);
@@ -885,6 +889,20 @@ public sealed class HarvesterRuntime : IDisposable
                 }
             }
         }
+    }
+
+    private static WatcherBinding MergeBindings(IReadOnlyList<WatcherBinding> bindings)
+    {
+        return new WatcherBinding
+        {
+            Servers = bindings
+                .SelectMany(binding => binding.Servers)
+                .Distinct()
+                .ToArray(),
+            WatchRules = bindings
+                .SelectMany(binding => binding.WatchRules)
+                .ToArray()
+        };
     }
 
     private async Task ProcessDetectedFileAsync(WatcherBinding binding, string path, string fileName,
@@ -965,6 +983,13 @@ public sealed class HarvesterRuntime : IDisposable
             {
                 try
                 {
+                    if (stopping.IsCancellationRequested)
+                    {
+                        _logger.LogWarning("Not deleting {Path}: cancellation requested before version probe", path);
+                        _health.RecordFileDeleteSkipped(path, "Cancellation requested before deletion version probe");
+                        return;
+                    }
+
                     SymbolFileVersion currentVersion = GetSymbolFileVersion(path);
                     if (currentVersion != snapshottedVersion)
                     {
@@ -979,6 +1004,13 @@ public sealed class HarvesterRuntime : IDisposable
                     }
                     else
                     {
+                        if (stopping.IsCancellationRequested)
+                        {
+                            _logger.LogWarning("Not deleting {Path}: cancellation requested before delete", path);
+                            _health.RecordFileDeleteSkipped(path, "Cancellation requested before delete");
+                            return;
+                        }
+
                         File.Delete(path);
                         _logger.LogInformation("Symbol file {Symbol} deleted", path);
                         _health.RecordFileDeleted(path);

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -524,9 +524,7 @@ public sealed class HarvesterRuntime : IDisposable
                     {
                         watcher = new FileSystemWatcher(item.Key.Path)
                         {
-                            NotifyFilter = NotifyFilters.Attributes
-                                           | NotifyFilters.CreationTime
-                                           | NotifyFilters.DirectoryName
+                            NotifyFilter = NotifyFilters.DirectoryName
                                            | NotifyFilters.FileName
                                            | NotifyFilters.LastWrite
                                            | NotifyFilters.Size,

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -947,8 +947,17 @@ public sealed class HarvesterRuntime : IDisposable
 
         try
         {
-            string? mimeType = MimeTypeMap.GetMimeType(Path.GetExtension(path));
-            ArgumentException.ThrowIfNullOrEmpty(mimeType);
+            string extension = Path.GetExtension(path);
+            string? mimeType = MimeTypeMap.GetMimeType(extension);
+            if (string.IsNullOrEmpty(mimeType))
+            {
+                mimeType = "application/octet-stream";
+                _logger.LogWarning(
+                    "Could not resolve MIME type for {Path} with extension {Extension}; using {MimeType}",
+                    path,
+                    extension,
+                    mimeType);
+            }
 
             Task<UploadAttemptResult>[] uploads = binding.Servers
                 .Select(serverConfig =>

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -1016,10 +1016,9 @@ public sealed class HarvesterRuntime : IDisposable
                         _health.RecordFileDeleted(path);
                     }
                 }
-                catch (FileNotFoundException)
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
                 {
-                    _logger.LogWarning("Not deleting {Path}: file no longer exists", path);
-                    _health.RecordFileDeleteFailed(path, "File not found");
+                    _logger.LogWarning("Not deleting {Path}: file no longer exists or directory vanished", path);
                 }
                 catch (Exception ex)
                 {

--- a/agent/HarvesterRuntime.cs
+++ b/agent/HarvesterRuntime.cs
@@ -15,6 +15,14 @@ public sealed class HarvesterRuntime : IDisposable
         public required IReadOnlyList<WatcherPathEntry> WatchRules { get; init; }
     }
 
+    private sealed class PendingFileEvent
+    {
+        public required string Path { get; init; }
+        public required string FileName { get; init; }
+        public required WatcherBinding Binding { get; set; }
+        public int Revision { get; set; }
+    }
+
     private sealed class UploadAttemptResult
     {
         public bool Success { get; init; }
@@ -69,6 +77,11 @@ public sealed class HarvesterRuntime : IDisposable
     /// </summary>
     private const int SnapshotMaxAttempts = 5;
 
+    /// <summary>
+    ///     Coalesces the burst of change notifications emitted while compilers and linkers are writing build outputs.
+    /// </summary>
+    private static readonly TimeSpan FileEventDebounceInterval = TimeSpan.FromSeconds(1);
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<HarvesterRuntime> _logger;
     private readonly AgentSettingsStore _store;
@@ -77,6 +90,7 @@ public sealed class HarvesterRuntime : IDisposable
 
     private readonly object _gate = new();
     private Dictionary<FileSystemWatcher, WatcherBinding>? _maps;
+    private readonly Dictionary<string, PendingFileEvent> _pendingFileEvents = new(StringComparer.OrdinalIgnoreCase);
     private bool _disposed;
 
     public HarvesterRuntime(
@@ -425,7 +439,7 @@ public sealed class HarvesterRuntime : IDisposable
     /// </summary>
     /// <remarks>
     /// Creates one watcher per unique normalized directory path and recursion setting, registers configured file filters
-    /// and servers for each watcher, attaches Created event handlers, replaces any existing watchers atomically, updates
+    /// and servers for each watcher, attaches file event handlers, replaces any existing watchers atomically, updates
     /// the runtime health state, and disposes old watchers.
     /// </remarks>
     /// <param name="cancellationToken">Cancellation token to abort the rebuild operation.</param>
@@ -551,7 +565,9 @@ public sealed class HarvesterRuntime : IDisposable
                     cancellationToken.ThrowIfCancellationRequested();
 
                     FileSystemWatcher w = map.Key;
-                    w.Created += WatcherOnCreated;
+                    w.Created += WatcherOnFileEvent;
+                    w.Changed += WatcherOnFileEvent;
+                    w.Renamed += WatcherOnRenamed;
                     w.EnableRaisingEvents = enable;
                     status.Add(new WatcherStatusEntry
                     {
@@ -656,7 +672,9 @@ public sealed class HarvesterRuntime : IDisposable
         int count = maps.Count;
         foreach (KeyValuePair<FileSystemWatcher, WatcherBinding> map in maps)
         {
-            map.Key.Created -= WatcherOnCreated;
+            map.Key.Created -= WatcherOnFileEvent;
+            map.Key.Changed -= WatcherOnFileEvent;
+            map.Key.Renamed -= WatcherOnRenamed;
             map.Key.EnableRaisingEvents = false;
             map.Key.Dispose();
         }
@@ -669,7 +687,7 @@ public sealed class HarvesterRuntime : IDisposable
     }
 
     /// <summary>
-    /// Begins background processing for a newly created filesystem entry detected by a FileSystemWatcher.
+    /// Begins background processing for a filesystem entry detected by a FileSystemWatcher.
     /// </summary>
     /// <remarks>
     /// Processing records the detection, waits for the file to become readable, snapshots the file to a temporary path,
@@ -680,165 +698,285 @@ public sealed class HarvesterRuntime : IDisposable
     /// </remarks>
     /// <param name="sender">The <see cref="FileSystemWatcher"/> that raised the event.</param>
     /// <param name="e">The <see cref="FileSystemEventArgs"/> containing the detected file path.</param>
-    private void WatcherOnCreated(object sender, FileSystemEventArgs e)
+    private void WatcherOnFileEvent(object sender, FileSystemEventArgs e)
+    {
+        QueueDetectedFileEvent(sender, e);
+    }
+
+    private void WatcherOnRenamed(object sender, RenamedEventArgs e)
+    {
+        QueueDetectedFileEvent(sender, e);
+    }
+
+    private void QueueDetectedFileEvent(object sender, FileSystemEventArgs e)
     {
         FileSystemWatcher? watcher = sender as FileSystemWatcher;
         ArgumentNullException.ThrowIfNull(watcher);
 
         CancellationToken stopping = _lifetime.ApplicationStopping;
 
-        Task.Run(async () =>
+        PendingFileEvent? pendingToProcess = null;
+
+        lock (_gate)
         {
-            try
+            if (_maps is null || !_maps.TryGetValue(watcher, out WatcherBinding? binding))
             {
-                WatcherBinding? binding;
+                return;
+            }
+
+            if (binding.Servers.Count == 0)
+            {
+                return;
+            }
+
+            string path = e.FullPath;
+            string fileName = Path.GetFileName(path);
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return;
+            }
+
+            if (_pendingFileEvents.TryGetValue(path, out PendingFileEvent? pending))
+            {
+                pending.Binding = binding;
+                pending.Revision++;
+                _logger.LogTrace(
+                    "Coalesced {ChangeType} event for {Path} into pending revision {Revision}",
+                    e.ChangeType,
+                    path,
+                    pending.Revision);
+                return;
+            }
+
+            pendingToProcess = new PendingFileEvent
+            {
+                Path = path,
+                FileName = fileName,
+                Binding = binding,
+                Revision = 1
+            };
+            _pendingFileEvents.Add(path, pendingToProcess);
+        }
+
+        if (pendingToProcess is null)
+        {
+            return;
+        }
+
+        PendingFileEvent queuedEvent = pendingToProcess;
+        _ = Task.Run(
+            () => ProcessPendingFileEventAsync(queuedEvent, stopping),
+            stopping);
+    }
+
+    private async Task ProcessPendingFileEventAsync(PendingFileEvent pending, CancellationToken stopping)
+    {
+        try
+        {
+            while (true)
+            {
+                int revision;
+                WatcherBinding binding;
+
                 lock (_gate)
                 {
-                    if (_maps is null || !_maps.TryGetValue(watcher, out binding))
+                    if (!_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) ||
+                        !ReferenceEquals(current, pending))
                     {
                         return;
                     }
+
+                    revision = pending.Revision;
+                    binding = pending.Binding;
                 }
 
-                if (binding.Servers.Count == 0)
+                await Task.Delay(FileEventDebounceInterval, stopping);
+
+                lock (_gate)
                 {
-                    return;
-                }
-
-                string path = e.FullPath;
-                string fileName = Path.GetFileName(path);
-                _health.RecordFileDetected(path);
-
-                string? snapshotPath = null;
-                SymbolFileVersion snapshottedVersion = default;
-                SymbolFileVersion versionAfterWait = default;
-
-                for (int attempt = 1; attempt <= SnapshotMaxAttempts; attempt++)
-                {
-                    versionAfterWait = await WaitForFileReadyAsync(path, stopping);
-
-                    try
+                    if (!_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) ||
+                        !ReferenceEquals(current, pending))
                     {
-                        (snapshotPath, snapshottedVersion) =
-                            await CreateUploadSnapshotAsync(path, versionAfterWait, stopping);
-                        break;
+                        return;
                     }
-                    catch (SnapshotVersionMismatchException ex)
+
+                    if (pending.Revision != revision)
                     {
-                        _logger.LogWarning(ex,
-                            "Snapshot attempt {Attempt}/{Max} for {Path} detected a concurrent modification; retrying",
-                            attempt,
-                            SnapshotMaxAttempts,
-                            path);
-
-                        if (attempt == SnapshotMaxAttempts)
-                        {
-                            throw;
-                        }
+                        continue;
                     }
-                }
-
-                if (snapshotPath is null)
-                {
-                    throw new InvalidOperationException(
-                        $"Could not capture a consistent snapshot of {path} after {SnapshotMaxAttempts} attempts.");
                 }
 
                 try
                 {
-                    string? mimeType = MimeTypeMap.GetMimeType(Path.GetExtension(path));
-                    ArgumentException.ThrowIfNullOrEmpty(mimeType);
-
-                    Task<UploadAttemptResult>[] uploads = binding.Servers
-                        .Select(serverConfig =>
-                            UploadToServerAsync(
-                                serverConfig,
-                                snapshotPath,
-                                path,
-                                fileName,
-                                mimeType,
-                                snapshottedVersion,
-                                stopping))
-                        .ToArray();
-
-                    UploadAttemptResult[] results = await Task.WhenAll(uploads);
-
-                    foreach (UploadAttemptResult result in results)
-                    {
-                        if (!result.Success)
-                        {
-                            _health.RecordFileUploadFailure(
-                                path,
-                                result.ServerDisplayName,
-                                result.ServerUrl,
-                                result.ErrorDetails ?? "Upload failed");
-                        }
-                    }
-
-                    bool allSucceeded = results.All(r => r.Success);
-                    bool shouldDelete = ShouldDeleteAfterAllSuccess(binding.WatchRules, fileName);
-
-                    if (allSucceeded && shouldDelete)
-                    {
-                        try
-                        {
-                            SymbolFileVersion currentVersion = GetSymbolFileVersion(path);
-                            if (currentVersion != snapshottedVersion)
-                            {
-                                _logger.LogWarning(
-                                    "Not deleting {Path}: file changed after snapshot (snapshotted version {Snapshotted}, current {Current})",
-                                    path,
-                                    snapshottedVersion,
-                                    currentVersion);
-                                _health.RecordFileDeleteSkipped(
-                                    path,
-                                    $"Version mismatch: snapshotted {snapshottedVersion}, current {currentVersion}");
-                            }
-                            else
-                            {
-                                File.Delete(path);
-                                _logger.LogInformation("Symbol file {Symbol} deleted", path);
-                                _health.RecordFileDeleted(path);
-                            }
-                        }
-                        catch (FileNotFoundException)
-                        {
-                            _logger.LogWarning("Not deleting {Path}: file no longer exists", path);
-                            _health.RecordFileDeleteFailed(path, "File not found");
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Could not verify or delete {Path} after upload", path);
-                            _health.RecordFileDeleteFailed(path, ex.Message);
-                        }
-                    }
+                    await ProcessDetectedFileAsync(binding, pending.Path, pending.FileName, stopping);
                 }
-                finally
+                catch (OperationCanceledException)
                 {
-                    if (snapshotPath is not null)
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to upload symbol {FullPath}", pending.Path);
+                    _health.RecordFileUploadFailure(pending.Path, null, null, ex.Message);
+                    _health.RecordError(ex.Message);
+                }
+
+                lock (_gate)
+                {
+                    if (!_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) ||
+                        !ReferenceEquals(current, pending))
                     {
-                        try
-                        {
-                            File.Delete(snapshotPath);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex, "Failed to delete temp upload snapshot {TempPath}", snapshotPath);
-                        }
+                        return;
+                    }
+
+                    if (pending.Revision == revision)
+                    {
+                        _pendingFileEvents.Remove(pending.Path);
+                        return;
                     }
                 }
             }
-            catch (OperationCanceledException)
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+        finally
+        {
+            lock (_gate)
             {
-                // shutdown
+                if (_pendingFileEvents.TryGetValue(pending.Path, out PendingFileEvent? current) &&
+                    ReferenceEquals(current, pending))
+                {
+                    _pendingFileEvents.Remove(pending.Path);
+                }
             }
-            catch (Exception ex)
+        }
+    }
+
+    private async Task ProcessDetectedFileAsync(WatcherBinding binding, string path, string fileName,
+        CancellationToken stopping)
+    {
+        _health.RecordFileDetected(path);
+
+        string? snapshotPath = null;
+        SymbolFileVersion snapshottedVersion = default;
+        SymbolFileVersion versionAfterWait = default;
+
+        for (int attempt = 1; attempt <= SnapshotMaxAttempts; attempt++)
+        {
+            versionAfterWait = await WaitForFileReadyAsync(path, stopping);
+
+            try
             {
-                _logger.LogError(ex, "Failed to upload symbol {FullPath}", e.FullPath);
-                _health.RecordFileUploadFailure(e.FullPath, null, null, ex.Message);
-                _health.RecordError(ex.Message);
+                (snapshotPath, snapshottedVersion) =
+                    await CreateUploadSnapshotAsync(path, versionAfterWait, stopping);
+                break;
             }
-        }, stopping);
+            catch (SnapshotVersionMismatchException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Snapshot attempt {Attempt}/{Max} for {Path} detected a concurrent modification; retrying",
+                    attempt,
+                    SnapshotMaxAttempts,
+                    path);
+
+                if (attempt == SnapshotMaxAttempts)
+                {
+                    throw;
+                }
+            }
+        }
+
+        if (snapshotPath is null)
+        {
+            throw new InvalidOperationException(
+                $"Could not capture a consistent snapshot of {path} after {SnapshotMaxAttempts} attempts.");
+        }
+
+        try
+        {
+            string? mimeType = MimeTypeMap.GetMimeType(Path.GetExtension(path));
+            ArgumentException.ThrowIfNullOrEmpty(mimeType);
+
+            Task<UploadAttemptResult>[] uploads = binding.Servers
+                .Select(serverConfig =>
+                    UploadToServerAsync(
+                        serverConfig,
+                        snapshotPath,
+                        path,
+                        fileName,
+                        mimeType,
+                        snapshottedVersion,
+                        stopping))
+                .ToArray();
+
+            UploadAttemptResult[] results = await Task.WhenAll(uploads);
+
+            foreach (UploadAttemptResult result in results)
+            {
+                if (!result.Success)
+                {
+                    _health.RecordFileUploadFailure(
+                        path,
+                        result.ServerDisplayName,
+                        result.ServerUrl,
+                        result.ErrorDetails ?? "Upload failed");
+                }
+            }
+
+            bool allSucceeded = results.All(r => r.Success);
+            bool shouldDelete = ShouldDeleteAfterAllSuccess(binding.WatchRules, fileName);
+
+            if (allSucceeded && shouldDelete)
+            {
+                try
+                {
+                    SymbolFileVersion currentVersion = GetSymbolFileVersion(path);
+                    if (currentVersion != snapshottedVersion)
+                    {
+                        _logger.LogWarning(
+                            "Not deleting {Path}: file changed after snapshot (snapshotted version {Snapshotted}, current {Current})",
+                            path,
+                            snapshottedVersion,
+                            currentVersion);
+                        _health.RecordFileDeleteSkipped(
+                            path,
+                            $"Version mismatch: snapshotted {snapshottedVersion}, current {currentVersion}");
+                    }
+                    else
+                    {
+                        File.Delete(path);
+                        _logger.LogInformation("Symbol file {Symbol} deleted", path);
+                        _health.RecordFileDeleted(path);
+                    }
+                }
+                catch (FileNotFoundException)
+                {
+                    _logger.LogWarning("Not deleting {Path}: file no longer exists", path);
+                    _health.RecordFileDeleteFailed(path, "File not found");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not verify or delete {Path} after upload", path);
+                    _health.RecordFileDeleteFailed(path, ex.Message);
+                }
+            }
+        }
+        finally
+        {
+            if (snapshotPath is not null)
+            {
+                try
+                {
+                    File.Delete(snapshotPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to delete temp upload snapshot {TempPath}", snapshotPath);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/agent/ServiceConfig.cs
+++ b/agent/ServiceConfig.cs
@@ -5,15 +5,34 @@ using JetBrains.Annotations;
 namespace HarvestingAgent;
 
 [UsedImplicitly]
-public sealed class AuthenticationConfig
+public sealed class AuthenticationConfig : IEquatable<AuthenticationConfig>
 {
     public string Username { get; set; } = "";
 
     public string Password { get; set; } = "";
+
+    public bool Equals(AuthenticationConfig? other)
+    {
+        return other is not null &&
+               string.Equals(Username, other.Username, StringComparison.Ordinal) &&
+               string.Equals(Password, other.Password, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as AuthenticationConfig);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(
+            StringComparer.Ordinal.GetHashCode(Username),
+            StringComparer.Ordinal.GetHashCode(Password));
+    }
 }
 
 [UsedImplicitly]
-public sealed class ServerConfig
+public sealed class ServerConfig : IEquatable<ServerConfig>
 {
     /// <summary>
     ///     Upload server authentication details.
@@ -59,6 +78,28 @@ public sealed class ServerConfig
     /// </summary>
     /// <remarks>See https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing</remarks>
     public List<string> DeletionExclusionFilter { get; set; } = [];
+
+    public bool Equals(ServerConfig? other)
+    {
+        return other is not null &&
+               EqualityComparer<Uri?>.Default.Equals(ServerUrl, other.ServerUrl) &&
+               EqualityComparer<AuthenticationConfig>.Default.Equals(Authentication, other.Authentication) &&
+               string.Equals(DisplayName, other.DisplayName, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as ServerConfig);
+    }
+
+    public override int GetHashCode()
+    {
+        HashCode hash = new();
+        hash.Add(ServerUrl);
+        hash.Add(Authentication);
+        hash.Add(DisplayName, StringComparer.Ordinal);
+        return hash.ToHashCode();
+    }
 }
 
 public sealed class ServiceConfig

--- a/tests/HarvestingAgent.Tests/HarvestingAgent.Tests.csproj
+++ b/tests/HarvestingAgent.Tests/HarvestingAgent.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\agent\HarvestingAgent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/HarvestingAgent.Tests/ServerConfigTests.cs
+++ b/tests/HarvestingAgent.Tests/ServerConfigTests.cs
@@ -1,0 +1,32 @@
+using HarvestingAgent;
+
+namespace HarvestingAgent.Tests;
+
+public class ServerConfigTests
+{
+    [Fact]
+    public void DistinctTreatsEquivalentServerConfigsAsEqual()
+    {
+        ServerConfig first = CreateServerConfig();
+        ServerConfig second = CreateServerConfig();
+
+        ServerConfig[] distinct = [.. new[] { first, second }.Distinct()];
+
+        Assert.Single(distinct);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    private static ServerConfig CreateServerConfig()
+    {
+        return new ServerConfig
+        {
+            ServerUrl = new Uri("https://symbols.example.test"),
+            DisplayName = "Private Symbols",
+            Authentication = new AuthenticationConfig
+            {
+                Username = "agent",
+                Password = "secret"
+            }
+        };
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Harvesting now detects renamed and modified files in addition to creations.
  * File notifications are queued, coalesced per path, and debounced (1s) to avoid duplicate work.
  * Pending work is invalidated when watchers are rebuilt, enabled/disabled, or disposed.

* **Refactor**
  * Snapshot → upload → delete workflow reorganized to keep retry behavior, record failures, and ensure temp snapshot cleanup.

* **Tests**
  * New test project and equality tests added for server configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->