### PR TITLE
Add configuration and service support for stale not-found placeholder cleanup

### DIFF
--- a/server/Core/NotFoundCleanupOptions.cs
+++ b/server/Core/NotFoundCleanupOptions.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace WinDbgSymbolsCachingProxy.Core;
+
+/// <summary>
+///     Controls the automatic pruning of stale not-found placeholders during the 404 recheck background job.
+/// </summary>
+[SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
+public sealed class NotFoundCleanupOptions
+{
+    /// <summary>
+    ///     When <see langword="true" /> (the default), stale not-found placeholders are deleted during the 404 recheck run.
+    ///     Set to <see langword="false" /> to disable all automatic cleanup.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    ///     A not-found placeholder is deleted when it has been requested by at least one client before but
+    ///     <see cref="WinDbgSymbolsCachingProxy.Models.SymbolsEntity.LastAccessedAt" /> is older than this threshold.
+    ///     Defaults to 180 days (~6 months).
+    /// </summary>
+    public TimeSpan InactiveAfter { get; set; } = TimeSpan.FromDays(180);
+
+    /// <summary>
+    ///     A not-found placeholder is deleted when it has <em>never</em> been accessed by a client
+    ///     (i.e. <see cref="WinDbgSymbolsCachingProxy.Models.SymbolsEntity.LastAccessedAt" /> is <see langword="null" />) and
+    ///     <see cref="WinDbgSymbolsCachingProxy.Models.SymbolsEntity.NotFoundAt" /> is older than this threshold.
+    ///     Defaults to 180 days (~6 months).
+    /// </summary>
+    public TimeSpan UnusedNotFoundAfter { get; set; } = TimeSpan.FromDays(180);
+}

--- a/server/Core/NotFoundCleanupOptions.cs
+++ b/server/Core/NotFoundCleanupOptions.cs
@@ -9,10 +9,10 @@ namespace WinDbgSymbolsCachingProxy.Core;
 public sealed class NotFoundCleanupOptions
 {
     /// <summary>
-    ///     When <see langword="true" /> (the default), stale not-found placeholders are deleted during the 404 recheck run.
-    ///     Set to <see langword="false" /> to disable all automatic cleanup.
+    ///     When <see langword="true" />, stale not-found placeholders are deleted during the 404 recheck run.
+    ///     Defaults to <see langword="false" />; opt in explicitly by setting this to <see langword="true" /> in configuration.
     /// </summary>
-    public bool Enabled { get; set; } = true;
+    public bool Enabled { get; set; } = false;
 
     /// <summary>
     ///     A not-found placeholder is deleted when it has been requested by at least one client before but

--- a/server/Core/ServiceConfig.cs
+++ b/server/Core/ServiceConfig.cs
@@ -42,4 +42,9 @@ public sealed class ServiceConfig
     ///     Option list of Basic Auth credentials for protected endpoints.
     /// </summary>
     public List<BasicAuthCredentials>? BasicAuthCredentials { get; set; }
+
+    /// <summary>
+    ///     Settings for the automatic cleanup of stale not-found placeholders run as part of the 404 recheck job.
+    /// </summary>
+    public NotFoundCleanupOptions NotFoundCleanup { get; set; } = new();
 }

--- a/server/README.md
+++ b/server/README.md
@@ -26,7 +26,7 @@ Edit [`appsettings.json`](appsettings.json) or environment-specific files such a
 | `UpstreamRecheckPeriod` | How long 404 cache entries wait before a background recheck |
 | `MemoryCacheSizeLimit` | In-memory cache cap (used for overview stats shared by `/info` and `/og/status.png`) |
 | `BasicAuthCredentials` | Allowed username/password pairs for upload API and authorized Blazor routes |
-| `NotFoundCleanup.Enabled` | `true` by default; set to `false` to disable automatic pruning of stale 404 placeholders |
+| `NotFoundCleanup.Enabled` | `false` by default; set to `true` to enable automatic pruning of stale 404 placeholders |
 | `NotFoundCleanup.InactiveAfter` | Placeholder that was requested at least once is deleted when `LastAccessedAt` is older than this threshold (default `180.00:00:00` — 180 days) |
 | `NotFoundCleanup.UnusedNotFoundAfter` | Placeholder that was **never** requested by any client is deleted when `NotFoundAt` is older than this threshold (default `180.00:00:00` — 180 days) |
 

--- a/server/README.md
+++ b/server/README.md
@@ -26,6 +26,9 @@ Edit [`appsettings.json`](appsettings.json) or environment-specific files such a
 | `UpstreamRecheckPeriod` | How long 404 cache entries wait before a background recheck |
 | `MemoryCacheSizeLimit` | In-memory cache cap (used for overview stats shared by `/info` and `/og/status.png`) |
 | `BasicAuthCredentials` | Allowed username/password pairs for upload API and authorized Blazor routes |
+| `NotFoundCleanup.Enabled` | `true` by default; set to `false` to disable automatic pruning of stale 404 placeholders |
+| `NotFoundCleanup.InactiveAfter` | Placeholder that was requested at least once is deleted when `LastAccessedAt` is older than this threshold (default `180.00:00:00` — 180 days) |
+| `NotFoundCleanup.UnusedNotFoundAfter` | Placeholder that was **never** requested by any client is deleted when `NotFoundAt` is older than this threshold (default `180.00:00:00` — 180 days) |
 
 ## Run locally
 

--- a/server/Services/RecheckNotFoundService.cs
+++ b/server/Services/RecheckNotFoundService.cs
@@ -172,6 +172,14 @@ public sealed class RecheckNotFoundService(
             return;
         }
 
+        if (cleanup.InactiveAfter <= TimeSpan.Zero || cleanup.UnusedNotFoundAfter <= TimeSpan.Zero)
+        {
+            logger.LogWarning(
+                "NotFoundCleanup: skipping pruning because {InactiveAfter} or {UnusedNotFoundAfter} is zero or negative — set both to a positive TimeSpan to enable cleanup",
+                cleanup.InactiveAfter, cleanup.UnusedNotFoundAfter);
+            return;
+        }
+
         DateTime inactiveCutoff = DateTime.UtcNow - cleanup.InactiveAfter;
         DateTime unusedCutoff = DateTime.UtcNow - cleanup.UnusedNotFoundAfter;
 

--- a/server/Services/RecheckNotFoundService.cs
+++ b/server/Services/RecheckNotFoundService.cs
@@ -1,13 +1,23 @@
 using System.Collections.Concurrent;
 using System.Net;
 
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+using MongoDB.Driver;
 using MongoDB.Entities;
 
+using WinDbgSymbolsCachingProxy.Core;
 using WinDbgSymbolsCachingProxy.Models;
 
 namespace WinDbgSymbolsCachingProxy.Services;
 
-public sealed class RecheckNotFoundService(DB db, IHttpClientFactory clientFactory, ILogger<RecheckNotFoundService> logger)
+public sealed class RecheckNotFoundService(
+    DB db,
+    IHttpClientFactory clientFactory,
+    ILogger<RecheckNotFoundService> logger,
+    IOptions<ServiceConfig> options,
+    IMemoryCache memoryCache)
 {
     /// <summary>
     ///     Queries all 404 symbols from DB and contacts the upstream server to check if they have become available since the
@@ -16,6 +26,8 @@ public sealed class RecheckNotFoundService(DB db, IHttpClientFactory clientFacto
     /// <param name="ct">Cancellation token to cancel the recheck operation.</param>
     public async Task Run(CancellationToken ct = default)
     {
+        await PruneStaleNotFoundAsync(ct);
+
         List<SymbolsEntity> notFoundSymbols = await db.Find<SymbolsEntity>().ManyAsync(
             sym => sym.NotFoundAt != null && !sym.IsCustom, ct);
 
@@ -134,5 +146,101 @@ public sealed class RecheckNotFoundService(DB db, IHttpClientFactory clientFacto
         logger.LogInformation(
             "RecheckNotFound finished: removed {ShadowRemoved} placeholders as alias-shadowed without upstream fetch",
             shadowRemoved.Count);
+    }
+
+    /// <summary>
+    ///     Deletes stale not-found placeholders from the database and evicts them from the memory cache.
+    ///     Two rules apply (both only to upstream, non-custom rows):
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <b>Rule A (inactive):</b> the symbol was requested at some point but
+    ///             <see cref="SymbolsEntity.LastAccessedAt" /> is older than <see cref="NotFoundCleanupOptions.InactiveAfter" />.
+    ///         </item>
+    ///         <item>
+    ///             <b>Rule B (unused):</b> the symbol was <em>never</em> requested by any client
+    ///             (<see cref="SymbolsEntity.LastAccessedAt" /> is <see langword="null" />) and
+    ///             <see cref="SymbolsEntity.NotFoundAt" /> is older than <see cref="NotFoundCleanupOptions.UnusedNotFoundAfter" />.
+    ///         </item>
+    ///     </list>
+    /// </summary>
+    private async Task PruneStaleNotFoundAsync(CancellationToken ct)
+    {
+        NotFoundCleanupOptions cleanup = options.Value.NotFoundCleanup;
+
+        if (!cleanup.Enabled)
+        {
+            return;
+        }
+
+        DateTime inactiveCutoff = DateTime.UtcNow - cleanup.InactiveAfter;
+        DateTime unusedCutoff = DateTime.UtcNow - cleanup.UnusedNotFoundAfter;
+
+        FilterDefinitionBuilder<SymbolsEntity> fb = Builders<SymbolsEntity>.Filter;
+
+        FilterDefinition<SymbolsEntity> filter = fb.And(
+            fb.Ne(s => s.IsCustom, true),
+            fb.Ne(s => s.NotFoundAt, null),
+            fb.Or(
+                // Rule A: had a client, but not recently
+                fb.And(
+                    fb.Ne(s => s.LastAccessedAt, null),
+                    fb.Lt(s => s.LastAccessedAt, inactiveCutoff)),
+                // Rule B: never had a client, 404 for too long
+                fb.And(
+                    fb.Eq(s => s.LastAccessedAt, (DateTime?)null),
+                    fb.Lt(s => s.NotFoundAt, unusedCutoff))));
+
+        List<SymbolsEntity> stale = await db.Find<SymbolsEntity>().Match(_ => filter).ExecuteAsync(ct);
+
+        if (stale.Count == 0)
+        {
+            logger.LogInformation("NotFoundCleanup: no stale placeholders found");
+            return;
+        }
+
+        int inactiveCount = stale.Count(s => s.LastAccessedAt is not null);
+        int unusedCount = stale.Count - inactiveCount;
+
+        foreach (SymbolsEntity s in stale)
+        {
+            memoryCache.Remove(s.RelativeUri);
+        }
+
+        IEnumerable<object> ids = stale.Select(s => (object)s.ID);
+        await db.DeleteAsync<SymbolsEntity>(ids, ct);
+
+        logger.LogInformation(
+            "NotFoundCleanup: removed {InactiveCount} inactive, {UnusedCount} unused placeholders",
+            inactiveCount, unusedCount);
+    }
+
+    /// <summary>
+    ///     Returns <see langword="true" /> when <paramref name="entity" /> matches the stale not-found cleanup predicate.
+    ///     This is the in-process equivalent of the MongoDB filter used in <see cref="PruneStaleNotFoundAsync" /> and is
+    ///     exposed as <see langword="internal" /> to allow unit-testing the rules without a live database.
+    /// </summary>
+    /// <param name="entity">The entity to evaluate.</param>
+    /// <param name="inactiveCutoff">
+    ///     Entities with a <see cref="SymbolsEntity.LastAccessedAt" /> strictly before this value match Rule A.
+    /// </param>
+    /// <param name="unusedCutoff">
+    ///     Entities with no <see cref="SymbolsEntity.LastAccessedAt" /> and a <see cref="SymbolsEntity.NotFoundAt" />
+    ///     strictly before this value match Rule B.
+    /// </param>
+    internal static bool IsStaleNotFound(SymbolsEntity entity, DateTime inactiveCutoff, DateTime unusedCutoff)
+    {
+        if (entity.IsCustom || entity.NotFoundAt is null)
+        {
+            return false;
+        }
+
+        // Rule A: was requested before but not recently
+        if (entity.LastAccessedAt is not null)
+        {
+            return entity.LastAccessedAt < inactiveCutoff;
+        }
+
+        // Rule B: never requested, 404 for too long
+        return entity.NotFoundAt < unusedCutoff;
     }
 }

--- a/server/appsettings.json
+++ b/server/appsettings.json
@@ -22,6 +22,11 @@
         "Username": "admin",
         "Password": "admin"
       }
-    ]
+    ],
+    "NotFoundCleanup": {
+      "Enabled": true,
+      "InactiveAfter": "180.00:00:00",
+      "UnusedNotFoundAfter": "180.00:00:00"
+    }
   }
 }

--- a/server/appsettings.json
+++ b/server/appsettings.json
@@ -24,7 +24,7 @@
       }
     ],
     "NotFoundCleanup": {
-      "Enabled": true,
+      "Enabled": false,
       "InactiveAfter": "180.00:00:00",
       "UnusedNotFoundAfter": "180.00:00:00"
     }

--- a/tests/WinDbgSymbolsCachingProxy.Server.Tests/RecheckNotFoundServiceCleanupTests.cs
+++ b/tests/WinDbgSymbolsCachingProxy.Server.Tests/RecheckNotFoundServiceCleanupTests.cs
@@ -179,15 +179,14 @@ public sealed class RecheckNotFoundServiceCleanupTests
     // ── Enabled flag ─────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Disabled_config_means_IsStaleNotFound_result_is_ignored_at_service_level()
+    public void IsStaleNotFound_Predicate_Ignores_EnabledFlag()
     {
-        // The service skips PruneStaleNotFoundAsync entirely when Enabled == false.
-        // At the predicate level we verify the rule still evaluates correctly — the
-        // caller (service) is responsible for gating on Enabled.
+        // IsStaleNotFound is a pure predicate; it deliberately does not know about
+        // the Enabled flag — that gating lives in PruneStaleNotFoundAsync, which
+        // returns early when Enabled == false (the default).
         NotFoundCleanupOptions disabled = new() { Enabled = false };
         Assert.False(disabled.Enabled);
 
-        // Even though the predicate would match, the service would skip it
         SymbolsEntity staleEntity = new()
         {
             IndexPrefix = "stale.pdb/ccc/",
@@ -197,7 +196,7 @@ public sealed class RecheckNotFoundServiceCleanupTests
             LastAccessedAt = null
         };
 
-        // Predicate itself doesn't know about Enabled — that's the service's concern
+        // Predicate matches regardless — the service gates on Enabled separately.
         Assert.True(RecheckNotFoundService.IsStaleNotFound(staleEntity, InactiveCutoff, UnusedCutoff));
     }
 }

--- a/tests/WinDbgSymbolsCachingProxy.Server.Tests/RecheckNotFoundServiceCleanupTests.cs
+++ b/tests/WinDbgSymbolsCachingProxy.Server.Tests/RecheckNotFoundServiceCleanupTests.cs
@@ -1,0 +1,203 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+using WinDbgSymbolsCachingProxy.Core;
+using WinDbgSymbolsCachingProxy.Models;
+using WinDbgSymbolsCachingProxy.Services;
+
+namespace WinDbgSymbolsCachingProxy.Server.Tests;
+
+/// <summary>
+///     Tests for the stale not-found cleanup predicate exposed by <see cref="RecheckNotFoundService.IsStaleNotFound" />.
+///     These tests exercise the in-process rule evaluation without requiring a live MongoDB instance.
+/// </summary>
+public sealed class RecheckNotFoundServiceCleanupTests
+{
+    private static readonly DateTime Now = new(2026, 5, 17, 0, 0, 0, DateTimeKind.Utc);
+
+    // Cutoffs matching the default 180-day thresholds
+    private static readonly DateTime InactiveCutoff = Now - TimeSpan.FromDays(180);
+    private static readonly DateTime UnusedCutoff = Now - TimeSpan.FromDays(180);
+
+    // ── Rule A (inactive): had a client, but LastAccessedAt is stale ────────────
+
+    [Fact]
+    public void RuleA_deletes_placeholder_whose_LastAccessedAt_is_before_cutoff()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "foo.pdb/abc/",
+            FileName = "foo.pdb",
+            SymbolKey = "abc",
+            NotFoundAt = Now - TimeSpan.FromDays(200),
+            LastAccessedAt = Now - TimeSpan.FromDays(181)
+        };
+
+        Assert.True(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    [Fact]
+    public void RuleA_keeps_placeholder_whose_LastAccessedAt_is_recent()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "foo.pdb/abc/",
+            FileName = "foo.pdb",
+            SymbolKey = "abc",
+            NotFoundAt = Now - TimeSpan.FromDays(200),
+            LastAccessedAt = Now - TimeSpan.FromDays(30)
+        };
+
+        Assert.False(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    [Fact]
+    public void RuleA_keeps_placeholder_whose_LastAccessedAt_equals_cutoff_exactly()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "foo.pdb/abc/",
+            FileName = "foo.pdb",
+            SymbolKey = "abc",
+            NotFoundAt = Now - TimeSpan.FromDays(200),
+            LastAccessedAt = InactiveCutoff
+        };
+
+        // Strict less-than: exactly at the cutoff should NOT be deleted
+        Assert.False(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    // ── Rule B (unused): never requested, NotFoundAt is stale ───────────────────
+
+    [Fact]
+    public void RuleB_deletes_placeholder_that_was_never_requested_and_NotFoundAt_is_old()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "bar.pdb/def/",
+            FileName = "bar.pdb",
+            SymbolKey = "def",
+            NotFoundAt = Now - TimeSpan.FromDays(181),
+            LastAccessedAt = null
+        };
+
+        Assert.True(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    [Fact]
+    public void RuleB_keeps_placeholder_that_was_never_requested_but_NotFoundAt_is_recent()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "bar.pdb/def/",
+            FileName = "bar.pdb",
+            SymbolKey = "def",
+            NotFoundAt = Now - TimeSpan.FromDays(30),
+            LastAccessedAt = null
+        };
+
+        Assert.False(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    // ── Custom-row immunity ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Custom_row_is_never_deleted_regardless_of_age()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "custom.pdb/xyz/",
+            FileName = "custom.pdb",
+            SymbolKey = "xyz",
+            IsCustom = true,
+            NotFoundAt = Now - TimeSpan.FromDays(400),
+            LastAccessedAt = Now - TimeSpan.FromDays(400)
+        };
+
+        Assert.False(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    [Fact]
+    public void Custom_row_without_LastAccessedAt_is_never_deleted()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "custom.pdb/xyz/",
+            FileName = "custom.pdb",
+            SymbolKey = "xyz",
+            IsCustom = true,
+            NotFoundAt = Now - TimeSpan.FromDays(400),
+            LastAccessedAt = null
+        };
+
+        Assert.False(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    // ── NotFoundAt == null (found/cached rows) are always kept ──────────────────
+
+    [Fact]
+    public void Row_without_NotFoundAt_is_never_deleted()
+    {
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "found.pdb/aaa/",
+            FileName = "found.pdb",
+            SymbolKey = "aaa",
+            NotFoundAt = null,
+            LastAccessedAt = Now - TimeSpan.FromDays(400)
+        };
+
+        Assert.False(RecheckNotFoundService.IsStaleNotFound(entity, InactiveCutoff, UnusedCutoff));
+    }
+
+    // ── Memory cache eviction ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Memory_cache_entry_for_stale_row_is_removed_on_eviction()
+    {
+        using MemoryCache cache = new(Options.Create(new MemoryCacheOptions()));
+
+        SymbolsEntity entity = new()
+        {
+            IndexPrefix = "evict.pdb/bbb/",
+            FileName = "evict.pdb",
+            SymbolKey = "bbb",
+            NotFoundAt = Now - TimeSpan.FromDays(200),
+            LastAccessedAt = Now - TimeSpan.FromDays(200)
+        };
+
+        string cacheKey = entity.RelativeUri;
+        cache.Set(cacheKey, entity);
+
+        Assert.True(cache.TryGetValue(cacheKey, out _), "entry should exist before eviction");
+
+        cache.Remove(cacheKey);
+
+        Assert.False(cache.TryGetValue(cacheKey, out _), "entry should be gone after eviction");
+    }
+
+    // ── Enabled flag ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Disabled_config_means_IsStaleNotFound_result_is_ignored_at_service_level()
+    {
+        // The service skips PruneStaleNotFoundAsync entirely when Enabled == false.
+        // At the predicate level we verify the rule still evaluates correctly — the
+        // caller (service) is responsible for gating on Enabled.
+        NotFoundCleanupOptions disabled = new() { Enabled = false };
+        Assert.False(disabled.Enabled);
+
+        // Even though the predicate would match, the service would skip it
+        SymbolsEntity staleEntity = new()
+        {
+            IndexPrefix = "stale.pdb/ccc/",
+            FileName = "stale.pdb",
+            SymbolKey = "ccc",
+            NotFoundAt = Now - TimeSpan.FromDays(300),
+            LastAccessedAt = null
+        };
+
+        // Predicate itself doesn't know about Enabled — that's the service's concern
+        Assert.True(RecheckNotFoundService.IsStaleNotFound(staleEntity, InactiveCutoff, UnusedCutoff));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pruning of stale "not found" symbol placeholders during scheduled rechecks; configurable and disabled by default (defaults: Disabled, 180 days inactive/unused thresholds).

* **Documentation**
  * Added configuration docs and default settings for the cleanup feature.

* **Tests**
  * Added unit tests covering cleanup rules, boundary cases, custom-row immunity, and cache eviction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/WinDbgSymbolsCachingProxy/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->